### PR TITLE
Find multi-arch base image with bb package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
 FROM alpine:3.19 as build
-RUN apk add --no-cache wget make gcc musl-dev curl
+RUN apk add --no-cache \
+    wget \
+    make \
+    gcc \
+    musl-dev \
+    curl \
+    ncurses-dev \
+    libx11-dev \
+    libxext-dev \
+    slang-dev \
+    autoconf \
+    automake \
+    libtool
 RUN wget https://sourceforge.net/projects/aa-project/files/aa-lib/1.4rc5/aalib-1.4rc5.tar.gz/download
 RUN tar -xzf download && rm download
 WORKDIR /aalib-1.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM debian@sha256:bd73076dc2cd9c88f48b5b358328f24f2a4289811bd73787c031e20db9f97123 as build
-RUN apt-get update
-RUN apt-get install -y wget make gcc curl
+FROM alpine:3.19 as build
+RUN apk add --no-cache wget make gcc musl-dev curl
 RUN wget https://sourceforge.net/projects/aa-project/files/aa-lib/1.4rc5/aalib-1.4rc5.tar.gz/download
 RUN tar -xzf download && rm download
 WORKDIR /aalib-1.4.0


### PR DESCRIPTION
- Switch from Debian (pinned SHA) to Alpine 3.19 for more reliable multi-arch builds
- Alpine provides better support across all target architectures (amd64, arm/v6, arm/v7, arm64, ppc64le, s390x)
- Significantly reduces base image size (~5MB vs ~120MB)
- Replace apt-get with apk package manager
- Add musl-dev package required for C compilation on Alpine