### PR TITLE
Fix multi-arch CI by cross-compiling with zig cc instead of QEMU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,71 @@
-FROM debian@sha256:bd73076dc2cd9c88f48b5b358328f24f2a4289811bd73787c031e20db9f97123 as build
-RUN apt-get update
-RUN apt-get install -y wget make gcc curl
-RUN wget https://sourceforge.net/projects/aa-project/files/aa-lib/1.4rc5/aalib-1.4rc5.tar.gz/download
-RUN tar -xzf download && rm download
+# syntax=docker/dockerfile:1
+#
+# True cross-compilation, no QEMU: this stage always runs on the native
+# builder architecture (--platform=$BUILDPLATFORM) and uses zig cc [1] to
+# cross-compile static musl binaries for every requested TARGETPLATFORM.
+# Faster and far more reliable than emulating apt/configure/make per-arch.
+# [1] https://andrewkelley.me/post/zig-cc-powerful-drop-in-substitute-gcc-clang.html
+FROM --platform=$BUILDPLATFORM debian:trixie-slim AS build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl xz-utils ca-certificates make binutils autotools-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG ZIG_VERSION=0.16.0
+ARG BUILDARCH
+RUN set -eux; \
+    case "${BUILDARCH}" in \
+      amd64) zigarch=x86_64 ;; \
+      arm64) zigarch=aarch64 ;; \
+      *) echo "unsupported builder arch ${BUILDARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fL "https://ziglang.org/download/${ZIG_VERSION}/zig-${zigarch}-linux-${ZIG_VERSION}.tar.xz" | tar -xJ -C /opt \
+    && mv "/opt/zig-${zigarch}-linux-${ZIG_VERSION}" /opt/zig
+ENV PATH="/opt/zig:${PATH}"
+
+# Map Docker's target platform to a zig/musl target triple. arm/v6 and arm/v7
+# share one triple: the v6 baseline zig emits runs fine on v7 hardware too.
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN set -eux; \
+    case "${TARGETARCH}${TARGETVARIANT}" in \
+      amd64)   triple=x86_64-linux-musl ;; \
+      arm64)   triple=aarch64-linux-musl ;; \
+      armv6)   triple=arm-linux-musleabihf ;; \
+      armv7)   triple=arm-linux-musleabihf ;; \
+      ppc64le) triple=powerpc64le-linux-musl ;; \
+      s390x)   triple=s390x-linux-musl ;; \
+      *) echo "unsupported platform ${TARGETARCH}${TARGETVARIANT}" >&2; exit 1 ;; \
+    esac; \
+    echo "$triple" > /triple; \
+    printf '#!/bin/sh\nexec zig cc -target %s "$@"\n' "$triple" > /usr/local/bin/musl-cc; \
+    printf '#!/bin/sh\nexec zig ar "$@"\n' > /usr/local/bin/musl-ar; \
+    printf '#!/bin/sh\nexec zig ranlib "$@"\n' > /usr/local/bin/musl-ranlib; \
+    chmod +x /usr/local/bin/musl-cc /usr/local/bin/musl-ar /usr/local/bin/musl-ranlib
+
+ENV CC=/usr/local/bin/musl-cc AR=/usr/local/bin/musl-ar RANLIB=/usr/local/bin/musl-ranlib
+# gnu89: this 2001-era C needs implicit-int/implicit-function-declaration/
+# incompatible-pointer-types downgraded from modern clang's default errors.
+# -O2 -fwrapv: zig cc's default -O0 traps signed-overflow (a real latent bug
+# in aalib's aamktabl.c this code has always relied on silently wrapping).
+ENV CFLAGS="-static -std=gnu89 -O2 -fwrapv -Wno-date-time -Wno-implicit-int -Wno-implicit-function-declaration -Wno-int-conversion -Wno-incompatible-function-pointer-types -Wno-return-type"
+
+RUN curl -fL 'https://sourceforge.net/projects/aa-project/files/aa-lib/1.4rc5/aalib-1.4rc5.tar.gz/download' -o aalib.tar.gz \
+    && tar -xzf aalib.tar.gz && rm aalib.tar.gz
 WORKDIR /aalib-1.4.0
-RUN curl 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' > ./config.guess
-RUN ./configure
-RUN make
-RUN make install
+RUN cp /usr/share/misc/config.guess /usr/share/misc/config.sub . \
+    && ./configure --host="$(cat /triple)" --disable-shared --enable-static \
+    && make && make install
 
 WORKDIR /
-RUN wget https://sourceforge.net/projects/aa-project/files/bb/1.3rc1/bb-1.3rc1.tar.gz/download
-RUN tar -xzf download && rm download
-WORKDIR bb-1.3.0
-RUN ./configure CFLAGS="-static"
-RUN make LDFLAGS="--static"
+RUN curl -fL 'https://sourceforge.net/projects/aa-project/files/bb/1.3rc1/bb-1.3rc1.tar.gz/download' -o bb.tar.gz \
+    && tar -xzf bb.tar.gz && rm bb.tar.gz
+WORKDIR /bb-1.3.0
+# regparm is an x86-only GCC attribute; bb's checked-in config.h applies it
+# unconditionally under __GNUC__, which zig's clang hard-errors on elsewhere.
+RUN sed -i 's/#define REGISTERS(n) __attribute__ ((regparm(n)))/#if defined(__i386__) || defined(__x86_64__)\n#define REGISTERS(n) __attribute__ ((regparm(n)))\n#else\n#define REGISTERS(n)\n#endif/' config.h \
+    && cp /usr/share/misc/config.guess /usr/share/misc/config.sub . \
+    && ./configure --host="$(cat /triple)" \
+    && make LDFLAGS="-static"
 
 FROM scratch
 COPY --from=build /bb-1.3.0/bb /bb


### PR DESCRIPTION
## Summary
- CI has been failing on every push: `curl` fetching a fresh `config.guess` from git.savannah.gnu.org lacked `-L`, so Savannah's 301 HTTPS redirect got written into `config.guess` as literal HTML — breaking every architecture identically, not just the exotic ones.
- Rather than just patching the curl call, this switches the build to real cross-compilation via [`zig cc`](https://andrewkelley.me/post/zig-cc-powerful-drop-in-substitute-gcc-clang.html) (build stage pinned to `--platform=$BUILDPLATFORM`, so it always runs natively) instead of QEMU-emulating the entire apt/configure/make toolchain per target arch. Static musl binaries are produced for all 6 platforms with no emulation during the build; final image stays `FROM scratch`.
- Also fixes latent bugs the old emulated build never got far enough to hit: modern clang's stricter default-error diagnostics on ancient K&R-style code (`-std=gnu89` + targeted `-Wno-*`), an x86-only `regparm` attribute applied unconditionally in `bb`'s checked-in `config.h`, and zig's default runtime overflow trap catching a real latent signed-overflow bug in `aalib`'s `aamktabl.c`.

## Test plan
- [x] Built all 6 target platforms locally (`linux/amd64`, `linux/arm/v6`, `linux/arm/v7`, `linux/arm64`, `linux/ppc64le`, `linux/s390x`) via `docker buildx build --platform ... -o type=cacheonly .` — all succeeded
- [x] Ran the resulting `amd64` binary natively
- [x] Ran the resulting `s390x` binary under QEMU emulation to confirm actual execution correctness, not just linking
- [ ] CI run on this PR (`Docker Image CI` workflow) green across all platforms

https://claude.ai/code/session_01F6QKUwwiAxLNkYn4dv5TfW