### PR TITLE
Add social preview meta tags, Google Analytics, favicon

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,28 @@
 <meta charset="utf-8">
 <title>bb — ASCII art demo (WebAssembly)</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="&quot;This demo requires computer at least as fast as 486/33 with coprocesor. But speed of 486/66 or pentium is highly recomended (especially for hight resolution SVGA modes). This demo does not require real operating system - works even under MS-DOS. For dual monitor modes you need secondary hercules / MDA compatible card. To compile demo you need 32 or 64 bit ANSI C compiler (no it does not compile under Borland one) and libraries listed bellow. PC speaker driver eats lots of CPU so running it at computers slower than pentium is really not good idea.&quot;">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://bb.cns.me/">
+<meta property="og:site_name" content="bb">
+<meta property="og:title" content="bb — ASCII art demo (WebAssembly)">
+<meta property="og:description" content="&quot;This demo requires computer at least as fast as 486/33 with coprocesor. But speed of 486/66 or pentium is highly recomended (especially for hight resolution SVGA modes). This demo does not require real operating system - works even under MS-DOS. For dual monitor modes you need secondary hercules / MDA compatible card. To compile demo you need 32 or 64 bit ANSI C compiler (no it does not compile under Borland one) and libraries listed bellow. PC speaker driver eats lots of CPU so running it at computers slower than pentium is really not good idea.&quot;">
+<meta property="og:image" content="https://bb.cns.me/bb-logo.jpg">
+<meta property="og:image:width" content="238">
+<meta property="og:image:height" content="173">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="bb — ASCII art demo (WebAssembly)">
+<meta name="twitter:description" content="&quot;This demo requires computer at least as fast as 486/33 with coprocesor. But speed of 486/66 or pentium is highly recomended (especially for hight resolution SVGA modes). This demo does not require real operating system - works even under MS-DOS. For dual monitor modes you need secondary hercules / MDA compatible card. To compile demo you need 32 or 64 bit ANSI C compiler (no it does not compile under Borland one) and libraries listed bellow. PC speaker driver eats lots of CPU so running it at computers slower than pentium is really not good idea.&quot;">
+<meta name="twitter:image" content="https://bb.cns.me/bb-logo.jpg">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-HHZBLWZ5Y2"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-HHZBLWZ5Y2');
+</script>
 <style>
   html, body {
     height: 100%;

--- a/web/index.html
+++ b/web/index.html
@@ -3,19 +3,20 @@
 <head>
 <meta charset="utf-8">
 <title>bb — ASCII art demo (WebAssembly)</title>
+<link rel="icon" href="bb-logo.jpg" type="image/jpeg">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content="&quot;This demo requires computer at least as fast as 486/33 with coprocesor. But speed of 486/66 or pentium is highly recomended (especially for hight resolution SVGA modes). This demo does not require real operating system - works even under MS-DOS. For dual monitor modes you need secondary hercules / MDA compatible card. To compile demo you need 32 or 64 bit ANSI C compiler (no it does not compile under Borland one) and libraries listed bellow. PC speaker driver eats lots of CPU so running it at computers slower than pentium is really not good idea.&quot;">
+<meta name="description" content="This demo requires computer at least as fast as 486/33 with coprocesor. But speed of 486/66 or pentium is highly recomended (especially for hight resolution SVGA modes). This demo does not require real operating system - works even under MS-DOS. For dual monitor modes you need secondary hercules / MDA compatible card. To compile demo you need 32 or 64 bit ANSI C compiler (no it does not compile under Borland one) and libraries listed bellow. PC speaker driver eats lots of CPU so running it at computers slower than pentium is really not good idea.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://bb.cns.me/">
 <meta property="og:site_name" content="bb">
 <meta property="og:title" content="bb — ASCII art demo (WebAssembly)">
-<meta property="og:description" content="&quot;This demo requires computer at least as fast as 486/33 with coprocesor. But speed of 486/66 or pentium is highly recomended (especially for hight resolution SVGA modes). This demo does not require real operating system - works even under MS-DOS. For dual monitor modes you need secondary hercules / MDA compatible card. To compile demo you need 32 or 64 bit ANSI C compiler (no it does not compile under Borland one) and libraries listed bellow. PC speaker driver eats lots of CPU so running it at computers slower than pentium is really not good idea.&quot;">
+<meta property="og:description" content="This demo requires computer at least as fast as 486/33 with coprocesor. But speed of 486/66 or pentium is highly recomended (especially for hight resolution SVGA modes). This demo does not require real operating system - works even under MS-DOS. For dual monitor modes you need secondary hercules / MDA compatible card. To compile demo you need 32 or 64 bit ANSI C compiler (no it does not compile under Borland one) and libraries listed bellow. PC speaker driver eats lots of CPU so running it at computers slower than pentium is really not good idea.">
 <meta property="og:image" content="https://bb.cns.me/bb-logo.jpg">
 <meta property="og:image:width" content="238">
 <meta property="og:image:height" content="173">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="bb — ASCII art demo (WebAssembly)">
-<meta name="twitter:description" content="&quot;This demo requires computer at least as fast as 486/33 with coprocesor. But speed of 486/66 or pentium is highly recomended (especially for hight resolution SVGA modes). This demo does not require real operating system - works even under MS-DOS. For dual monitor modes you need secondary hercules / MDA compatible card. To compile demo you need 32 or 64 bit ANSI C compiler (no it does not compile under Borland one) and libraries listed bellow. PC speaker driver eats lots of CPU so running it at computers slower than pentium is really not good idea.&quot;">
+<meta name="twitter:description" content="This demo requires computer at least as fast as 486/33 with coprocesor. But speed of 486/66 or pentium is highly recomended (especially for hight resolution SVGA modes). This demo does not require real operating system - works even under MS-DOS. For dual monitor modes you need secondary hercules / MDA compatible card. To compile demo you need 32 or 64 bit ANSI C compiler (no it does not compile under Borland one) and libraries listed bellow. PC speaker driver eats lots of CPU so running it at computers slower than pentium is really not good idea.">
 <meta name="twitter:image" content="https://bb.cns.me/bb-logo.jpg">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-HHZBLWZ5Y2"></script>
@@ -110,6 +111,11 @@
     font-style: italic;
     margin-top: 0.4rem;
   }
+  footer .credit {
+    color: #2a2a2a;
+    margin-top: 0.6rem;
+  }
+  footer .credit a { color: #3a3a3a; }
 </style>
 </head>
 <body>
@@ -140,6 +146,11 @@
       compiler (no it does not compile under Borland one) and libraries listed
       bellow. PC speaker driver eats lots of CPU so running it at computers
       slower than pentium is really not good idea.&rdquo;
+    </div>
+    <div class="credit">
+      <a href="https://github.com/chrisns/docker-bb">repo</a>
+      &middot;
+      <a href="https://cns.me">cns.me</a>
     </div>
   </footer>
   <script type="module" src="app.js"></script>


### PR DESCRIPTION
## Summary
- Open Graph + Twitter Card meta tags for rich link previews: uses the original bb logo as the image and the page's own system-requirements blurb as the description, so a shared link matches what the page itself says.
- Google Analytics (gtag.js) snippet.
- Favicon: the bb logo.
- A subtle repo/cns.me credit line at the bottom of the footer.

## Test plan
- [x] Built and served locally, confirmed meta tags render correctly and footer credit line displays
- [ ] CI on this PR

https://claude.ai/code/session_01F6QKUwwiAxLNkYn4dv5TfW